### PR TITLE
Creed.md/readme.md

### DIFF
--- a/CREED.md
+++ b/CREED.md
@@ -1,0 +1,31 @@
+# CREED
+
+## *Contributors pledge to the following codes of conduct:*
+
+### 1. Communication
+
+Communicating when completing a major milestone/deliverable (message/text). We will be using Slack, Zoom meeting rooms and Discord (preferable).
+
+### 2. Decision-Making
+
+Collaboration - when at a crossroads: everyone comes together to discuss/talk about their feelings/opinions/options and strategies and together reach a decision.
+
+### 3. Conflict Management
+
+Acknowledging that there is a problem, even if the problem is between two people, having the team involved is better so that there is a mediator and perhaps this problem is a team problem as well. If anything escalates, we involve the PL.
+
+### 4. Accountability
+
+C.A.R. as well as having daily goals and end-of-day reports.
+
+### 5. DEI
+
+Having an open mind and having the freedom to express opinions and being included.
+
+### 6. Respect
+
+No interruption when speaking and attentively listening.
+
+### 7. Support
+
+Reaching out when in need of help or support and without hesitation.

--- a/CREED.md
+++ b/CREED.md
@@ -1,6 +1,6 @@
 # CREED
 
-## *Contributors pledge to the following codes of conduct:*
+*Contributors pledge to the following codes of conduct:*
 
 ### 1. Communication
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ## *Welcome to Team Dijkstra's Front-End Capstone project.*
 
-To begin, install npm dependencies locally by running:
+### **To Begin**
+
+Install npm dependencies locally by running:
 
 `npm install`
 
@@ -13,5 +15,13 @@ Build the webpack bundle.js and watch for file changes:
 Then initiate the express server to listen on the specified port:
 
 `npm start`
+
+### **API**
+
+Create a new root file 'token.js' and populate it with the same contents as provided in 'token.sample.js'.
+
+Replace 'YOUR_API_TOKEN_HERE' with a [GitHub personal access token](https://github.com/settings/tokens)
+
+*Note: Confirm that 'token.js' is listed in the '.gitignore' root file so that it is never checked into Git. If the token becomes compromised, please revoke the token immediately and generate a new one.*
 
 ### *To be continued...*

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Front-End Capstone
 
-## *Welcome to Team Dijkstra's Front-End Capstone project.*
+*Welcome to Team Dijkstra's Front-End Capstone project.*
 
-### **To Begin**
+## **To Begin**
 
 Install npm dependencies locally by running:
 
@@ -16,7 +16,7 @@ Then initiate the express server to listen on the specified port:
 
 `npm start`
 
-### **API**
+## **API**
 
 Create a new root file 'token.js' and populate it with the same contents as provided in 'token.sample.js'.
 


### PR DESCRIPTION
I noticed in the pyroscope repo they included a code of conduct .md in the root and I thought that was really cool to include that so show contributors are expected to respect those rules. I figured since we already have a creed we could include it in a similar way.

I also updated the README.md to include api token instructions.